### PR TITLE
skal ikke sende hvis macgyver er source for å unngå duplikater

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/SendtSykmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/SendtSykmeldingService.kt
@@ -31,7 +31,7 @@ class SendtSykmeldingService(
 
     private suspend fun handleSendtSykmelding(sendtSykmeldingKafkaMessage: SendtSykmeldingKafkaMessage) {
         log.info("Mottok sendt sykmelding fra Kafka med sykmeldingId: ${sendtSykmeldingKafkaMessage.kafkaMetadata.sykmeldingId}, source: ${sendtSykmeldingKafkaMessage.kafkaMetadata.source} ${when (sendtSykmeldingKafkaMessage.kafkaMetadata.source) { "syfoservice" -> "ignoring" else -> "sending to altinn"}}")
-        if (sendtSykmeldingKafkaMessage.kafkaMetadata.source == "syfoservice") {
+        if (sendtSykmeldingKafkaMessage.kafkaMetadata.source == "syfoservice" || sendtSykmeldingKafkaMessage.kafkaMetadata.source == "macgyver") {
             return
         }
         val person = pdlClient.getPerson(


### PR DESCRIPTION
Syfosmaltinn har egentlig duplikatsjekk og skal ikke sende ting den har sendt før, så dette er kun for å unngå at sykmeldinger som opprinnelig har blitt sendt med syfoservice sendes på nytt hvis vi må rette sykmeldingen. 